### PR TITLE
Zcash coding support

### DIFF
--- a/block.ipldsch
+++ b/block.ipldsch
@@ -71,18 +71,19 @@ type TxOut struct {
   scriptPubKey MaybePubKey # unbounded vec<char>
 }
 
-# A faux kinded union, this field is only a WitnessTransactionMerkle hash for
+# A faux kinded union, this field is only a WitnessCommitment hash for
 # SegWit transactions with one of the coinbase TxOuts where the field starts
-# with the bytes [0xaa, 0x21, 0xa9, 0xed], the remainder is taken to be the
-# txWitnessMerkleRoot. Otherwise the field can be interpreted as a scriptPubKey
+# with the bytes [0x6a, 0x24, 0xaa, 0x21, 0xa9, 0xed], the remainder is taken to
+# be the txWitnessMerkleRoot. Otherwise the field can be interpreted as a
+# scriptPubKey
 type MaybePubKey union {
-  | ScriptPubKey string
-  | &WitnessTransactionMerkle link
+  | ScriptPubKey bytes
+  | &WitnessCommitment link
 } representation kinded
 
-type ScriptPubKey string
+type ScriptPubKey bytes
 
-type WitnessTransactionMerkle struct {
+type WitnessCommitment struct {
   nonce Bytes # 256-bits, attached to the coinbase TxIn as its scriptWitness
   txWitnessMerkleRoot &TransactionMerkle
 }

--- a/classes/Block.js
+++ b/classes/Block.js
@@ -349,6 +349,9 @@ BitcoinBlock.fromPorcelain = function fromPorcelain (porcelain) {
   if (typeof porcelain.time !== 'number') {
     throw new TypeError('time property must be a number')
   }
+  if (typeof porcelain.nonce !== 'number') {
+    throw new TypeError('nonce property must be a number')
+  }
   if (typeof porcelain.bits !== 'string' && !/^[0-9a-f]+$/.test(porcelain.bits)) {
     throw new TypeError('bits property must be a hex string')
   }

--- a/classes/Transaction.js
+++ b/classes/Transaction.js
@@ -425,9 +425,7 @@ BitcoinTransaction._customDecodeBytes = function (decoder, properties, state) {
 }
 
 BitcoinTransaction._customDecodeHash = function (decoder, properties, state) {
-  const start = state.transactionStartPos
-  const end = decoder.currentPosition()
-  const hashBytes = decoder.absoluteSlice(start, end - start)
+  const hashBytes = properties[properties.length - 1] // rawBytes
   const digest = dblSha2256(hashBytes)
   properties.push(digest)
 }

--- a/coding.js
+++ b/coding.js
@@ -248,7 +248,6 @@ function decodeType (buf, type, strictLengthUsage) {
       return i
     },
 
-    // NOTE: this is actually a uint, if you need signed then you may be in trouble
     readBigInt64LE () {
       // not browser friendly, need to simulate:
       // const i = buf.readBigInt64LE(pos)
@@ -271,8 +270,7 @@ function decodeType (buf, type, strictLengthUsage) {
       const hi = buf[pos + 4] +
         buf[pos + 5] * 2 ** 8 +
         buf[pos + 6] * 2 ** 16 +
-        buf[pos + 7] * 2 ** 24
-      // uint might &0x7f the first and then check the &0x80 bit for signedness
+        (buf[pos + 7] << 24) // possible overflow
       const lo = buf[pos] +
         buf[pos + 1] * 2 ** 8 +
         buf[pos + 2] * 2 ** 16 +

--- a/coding.js
+++ b/coding.js
@@ -87,25 +87,18 @@ const encoders = {
 
   int64_t: function * writeBigInt64LE (v) {
     const buf = Buffer.alloc(8)
-    let lo = v & 0xffffffff
-    buf[0] = lo
-    lo = lo >> 8
-    buf[1] = lo
-    lo = lo >> 8
-    buf[2] = lo
-    lo = lo >> 8
-    buf[3] = lo
+    buf[0] = v
+    buf[1] = v >> 8
+    buf[2] = v >> 16
+    buf[3] = v >> 24
     let hi = (v / (2 ** 32)) & 0xffffffff
     if (v < 0) {
       hi -= 1
     }
     buf[4] = hi
-    hi = hi >> 8
-    buf[5] = hi
-    hi = hi >> 8
-    buf[6] = hi
-    hi = hi >> 8
-    buf[7] = hi
+    buf[5] = hi >> 8
+    buf[6] = hi >> 16
+    buf[7] = hi >> 24
     if (module.exports.DEBUG) {
       console.log(`int64_t: ${buf.toString('hex')}`)
     }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "bitcoin-block.js",
   "dependencies": {
     "bech32": "^1.1.4",
-    "multibase": "^0.7.0",
+    "multibase": "^1.0.0",
     "multihashing": "^0.3.3",
     "ripemd160": "^2.0.2"
   },


### PR DESCRIPTION
To support this module being pulled back into zcash-block and the `require('bitcoin-block/coding')` being used for decode.

Still would like to find a way to make coding pluggable so the Zcash specific pieces don't need to be kept in here. But that's a later job.